### PR TITLE
My version of vagrant has a slightly different syntax for vagrant ssh-co...

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -354,7 +354,7 @@ def _get_vagrant_config():
     Parses vagrant configuration and returns it as dict of ssh parameters
     and their values
     """
-    result = local('vagrant ssh_config', capture=True)
+    result = local('vagrant ssh-config', capture=True)
     conf = {}
     for line in iter(result.splitlines()):
         parts = line.split()


### PR DESCRIPTION
...nfig.  I am using this as a guide because I am actually running a two computer solution where my vagrant installation is on a seperate computer to my fabric host.
